### PR TITLE
Add support for Cabal

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ request.
 | yarn      | JavaScript, etc. | `package.json` and `yarn.lock`             | `yarn build` <br/> `yarn start` <br/> `yarn test`      |
 | Maven     | Java, etc.       | `pom.xml`                                  | `mvn compile` <br/> run n/a <br/> `mvn test`           |
 | Leiningen | Clojure          | `project.clj`                              | `lein test`                                            |
+| Cabal     | Haskell          | `*.cabal`                                  | `cabal build` <br/> `cabal run` <br/> `cabal test`     |
 | Stack     | Haskell          | `stack.yaml`                               | `stack build` <br/> `stack run` <br/> `stack test`     |
 | make      | Any              | `Makefile` with a `test`/`check` target    | `make test/check`                                      |
 | Mage      | Go               | `magefile.go` with a `test`/`check` target | `mage test/check`                                      |

--- a/projectdo
+++ b/projectdo
@@ -127,6 +127,15 @@ try_stack() {
   fi
 }
 
+# Haskell + Cabal
+
+try_cabal() {
+  cabal_file="$(find ./ -maxdepth 1 -name "*.cabal" 2> /dev/null | wc -l)"
+  if [ "$cabal_file" -gt 0 ] && [ ! -f stack.yml ]; then
+    execute_command cabal "$ACTION"
+  fi
+}
+
 # Maven
 
 try_maven() {
@@ -248,6 +257,7 @@ detect_and_run() {
   try_nodejs
   try_cargo
   try_stack
+  try_cabal
   try_cmake
   try_maven
   try_lein


### PR DESCRIPTION
This pull request adds support for Haskell projects that are using Cabal without Stack. It does so by checking for the existence of a Cabal project file with the `*.cabal` extension while also ensuring that there are no `stack.yaml` file.

In a Stack project, `projectdo` gives me the following:
```
~/passphrase (main) % projectdo -d build
stack build
~/passphrase (main) % projectdo -d test 
stack test
~/passphrase (main) % projectdo -d run
stack run
```

In a Cabal project, `projectdo` gives me this:
```
~/cis194 (main) % projectdo -d build
cabal build
~/cis194 (main) % projectdo -d test
cabal test
~/cis194 (main) % projectdo -d run  
cabal run
```