### PR TITLE
Add support for Mason

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ request.
 |-----------|------------------|--------------------------------------------|--------------------------------------------------------|
 | Cargo     | Rust             | `Cargo.toml`                               | `cargo build` <br/> `cargo run` <br/> `cargo test`     |
 | Poetry    | Python           | `pyproject.toml` with `[tool.poetry]`      | `poetry build` <br/> run n/a <br/> `poetry run pytest` |
-| CMake     | C/C++/Obj-C      | `CMakeLists.txt`                           | `cmake --build . --target test`                        |
+| CMake     | C, C++ and Obj-C | `CMakeLists.txt`                           | `cmake --build . --target test`                        |
+| Meson     | C, C++, etc.     | `meson.build`                              | `meson compile` <br/> run n/a <br/> `meson test`       |
 | npm       | JavaScript, etc. | `package.json`                             | `npm build` <br/> `npm start` <br/> `npm test`         |
 | yarn      | JavaScript, etc. | `package.json` and `yarn.lock`             | `yarn build` <br/> `yarn start` <br/> `yarn test`      |
 | Maven     | Java, etc.       | `pom.xml`                                  | `mvn compile` <br/> run n/a <br/> `mvn test`           |

--- a/projectdo
+++ b/projectdo
@@ -107,19 +107,6 @@ try_cargo() {
   fi
 }
 
-# CMake
-
-try_cmake() {
-  if [ -f CMakeLists.txt ] && [ "$ACTION" = test ]; then
-    if [ -f build ]; then
-      execute "cmake --build build --target test"
-    else
-      execute "cmake --build . --target test"
-    fi
-    exit
-  fi
-}
-
 # Meson
 
 try_meson() {
@@ -135,6 +122,19 @@ try_meson() {
         echo "projectdo does not know how to run a project with Meson."
         exit
     esac
+  fi
+}
+
+# CMake
+
+try_cmake() {
+  if [ -f CMakeLists.txt ] && [ "$ACTION" = test ]; then
+    if [ -f build ]; then
+      execute "cmake --build build --target test"
+    else
+      execute "cmake --build . --target test"
+    fi
+    exit
   fi
 }
 
@@ -290,8 +290,8 @@ detect_and_run() {
   try_cargo
   try_stack
   try_cabal
-  try_cmake
   try_meson
+  try_cmake
   try_maven
   try_lein
   try_makefile

--- a/projectdo
+++ b/projectdo
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-VERSION="0.2.0"
+VERSION="0.2.1"
 
 # Global mutable variables.
 QUIET=false
@@ -117,6 +117,24 @@ try_cmake() {
       execute "cmake --build . --target test"
     fi
     exit
+  fi
+}
+
+# Meson
+
+try_meson() {
+  if [ -f meson.build ]; then
+    case $ACTION in
+      build)
+        execute "meson compile"
+        exit ;;
+      test)
+        execute "meson test"
+        exit ;;
+      run)
+        echo "projectdo does not know how to run a project with Meson."
+        exit
+    esac
   fi
 }
 
@@ -273,6 +291,7 @@ detect_and_run() {
   try_stack
   try_cabal
   try_cmake
+  try_meson
   try_maven
   try_lein
   try_makefile

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -187,6 +187,17 @@ if describe "latex"; then
   fi
 fi
 
+if describe "meson"; then
+  if it "can build with meson"; then
+    do_build_in "meson"; assert
+    assertEqual "$RUN_RESULT" "meson compile"
+  fi
+  if it "can test with meson"; then
+    do_test_in "meson"; assert
+    assertEqual "$RUN_RESULT" "meson test"
+  fi
+fi
+
 echo ""
 
 if [ $ANY_ERRORS = true ]; then

--- a/tests/meson/meson.build
+++ b/tests/meson/meson.build
@@ -1,0 +1,8 @@
+project('meson', 'c',
+  version : '0.1',
+  default_options : ['warning_level=3'])
+
+exe = executable('meson', 'meson.c',
+  install : true)
+
+test('basic', exe)

--- a/tests/meson/meson.c
+++ b/tests/meson/meson.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+#define PROJECT_NAME "meson"
+
+int main(int argc, char **argv) {
+    if(argc != 1) {
+        printf("%s takes no arguments.\n", argv[0]);
+        return 1;
+    }
+    printf("This is project %s.\n", PROJECT_NAME);
+    return 0;
+}


### PR DESCRIPTION
Mason is detected by a `meson.build` file. Test is mapped to `mason test` and build is mapped to `meson compile`. I could not find a "run"-like action for Meson so that is not supported.

#12