### PR TITLE
Fix ShellCheck errors + Add support for generic shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,16 @@
+PREFIX ?= /usr
+BINARY_NAME = projectdo
+
+all:
+	@echo RUN \'make install\' to install $(BINARY_NAME)
+	@echo RUN \'make uninstall\' to uninstall $(BINARY_NAME)
+	@echo RUN \'make test\' to run tests for $(BINARY_NAME)
+
+install:
+	@install -Dm755 $(BINARY_NAME) $(DESTDIR)$(PREFIX)/bin/$(BINARY_NAME)
+
+uninstall:
+	@rm -f $(DESTDIR)$(PREFIX)/bin/$(BINARY_NAME)
+
 test:
 	sh run-tests.sh

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ curl https://raw.githubusercontent.com/paldepind/projectdo/main/projectdo -o ~/b
 chmod +x ~/bin/projectdo
 ```
 
+#### From repository
+
+Clone the project repository:
+
+```sh
+git clone https://github.com/paldepind/projectdo; cd projectdo
+```
+
+Install it with this command:
+
+```sh
+make install
+
+# Or to uninstall
+make uninstall
+```
+
 ## Shell integration
 
 For the Fish shell use [the Fish plugin](#fish-plugin). For Bash and Zsh setup
@@ -153,20 +170,21 @@ Tool arguments:
 **Note:** If a tool you are interested in is not supported please open an issue or a pull
 request.
 
-| Tool      | Language         | Detected by                                | Commands                                               |
-|-----------|------------------|--------------------------------------------|--------------------------------------------------------|
-| Cargo     | Rust             | `Cargo.toml`                               | `cargo build` <br/> `cargo run` <br/> `cargo test`     |
-| Poetry    | Python           | `pyproject.toml` with `[tool.poetry]`      | `poetry build` <br/> run n/a <br/> `poetry run pytest` |
-| CMake     | C, C++ and Obj-C | `CMakeLists.txt`                           | `cmake --build . --target test`                        |
-| Meson     | C, C++, etc.     | `meson.build`                              | `meson compile` <br/> run n/a <br/> `meson test`       |
-| npm       | JavaScript, etc. | `package.json`                             | `npm build` <br/> `npm start` <br/> `npm test`         |
-| yarn      | JavaScript, etc. | `package.json` and `yarn.lock`             | `yarn build` <br/> `yarn start` <br/> `yarn test`      |
-| Maven     | Java, etc.       | `pom.xml`                                  | `mvn compile` <br/> run n/a <br/> `mvn test`           |
-| Leiningen | Clojure          | `project.clj`                              | `lein test`                                            |
-| Cabal     | Haskell          | `*.cabal`                                  | `cabal build` <br/> `cabal run` <br/> `cabal test`     |
-| Stack     | Haskell          | `stack.yaml`                               | `stack build` <br/> `stack run` <br/> `stack test`     |
-| make      | Any              | `Makefile`                                 | `make` <br/> `make test/check`                         |
-| Mage      | Go               | `magefile.go` with a `test`/`check` target | `mage test/check`                                      |
-| Go        | Go               | `go.mod`                                   | `go test`                                              |
-| Tectonic  | LaTeX            | `Tectonic.toml`                            | `tectonic -X build`                                    |
+| Tool         | Language         | Detected by                                | Commands                                               |
+|--------------|------------------|--------------------------------------------|--------------------------------------------------------|
+| Cargo        | Rust             | `Cargo.toml`                               | `cargo build` <br/> `cargo run` <br/> `cargo test`     |
+| Poetry       | Python           | `pyproject.toml` with `[tool.poetry]`      | `poetry build` <br/> run n/a <br/> `poetry run pytest` |
+| CMake        | C, C++ and Obj-C | `CMakeLists.txt`                           | `cmake --build . --target test`                        |
+| Meson        | C, C++, etc.     | `meson.build`                              | `meson compile` <br/> run n/a <br/> `meson test`       |
+| npm          | JavaScript, etc. | `package.json`                             | `npm build` <br/> `npm start` <br/> `npm test`         |
+| yarn         | JavaScript, etc. | `package.json` and `yarn.lock`             | `yarn build` <br/> `yarn start` <br/> `yarn test`      |
+| Maven        | Java, etc.       | `pom.xml`                                  | `mvn compile` <br/> run n/a <br/> `mvn test`           |
+| Leiningen    | Clojure          | `project.clj`                              | `lein test`                                            |
+| Cabal        | Haskell          | `*.cabal`                                  | `cabal build` <br/> `cabal run` <br/> `cabal test`     |
+| Stack        | Haskell          | `stack.yaml`                               | `stack build` <br/> `stack run` <br/> `stack test`     |
+| make         | Any              | `Makefile`                                 | `make` <br/> `make test/check`                         |
+| Mage         | Go               | `magefile.go` with a `test`/`check` target | `mage test/check`                                      |
+| Go           | Go               | `go.mod`                                   | `go test`                                              |
+| Tectonic     | LaTeX            | `Tectonic.toml`                            | `tectonic -X build`                                    |
+| Shell script | Any              | `build.sh`                                 | `sh -c build.sh`                                       |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projectdo",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Context-aware single-letter project commands to speed up your terminal workflow.",
   "bin": {
     "projectdo": "./projectdo"

--- a/projectdo
+++ b/projectdo
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-VERSION="0.2.1"
+VERSION="0.2.2"
 
 # Global mutable variables.
 QUIET=false
@@ -287,6 +287,20 @@ try_latex() {
   fi
 }
 
+# Any / Generic
+
+try_build_script() {
+  if [ "$ACTION" = build ]; then
+    if [ -f build.sh ]; then
+      execute "sh -c build.sh"
+      exit
+    else
+      echo "Did not find build.sh script"
+      exit
+    fi
+  fi
+}
+
 # End of list of tools
 
 detect_and_run() {
@@ -302,6 +316,7 @@ detect_and_run() {
   try_python
   try_go
   try_latex
+  try_build_script
 }
 
 set_project_root() {

--- a/projectdo
+++ b/projectdo
@@ -34,7 +34,11 @@ has_command() {
 # evaluates the given command while respecting $QUIET and $DRY_RUN.
 execute() {
   if [ $QUIET = false ]; then
-    echo "$1" "$TOOL_ARGS"
+    if [ -z "$TOOL_ARGS" ]; then
+      printf '%s' "$1"
+    else
+      printf '%s %s' "$1" "$TOOL_ARGS"
+    fi
   fi
   if [ $DRY_RUN = false ]; then
     if [ $QUIET = false ]; then
@@ -291,11 +295,8 @@ try_latex() {
 
 try_build_script() {
   if [ "$ACTION" = build ]; then
-    if [ -f build.sh ]; then
+    if [ -f ./build.sh ]; then
       execute "sh -c build.sh"
-      exit
-    else
-      echo "Did not find build.sh script"
       exit
     fi
   fi
@@ -391,7 +392,7 @@ if [ "$1" = test ] ||
     IS_TOOL=true
   fi
   shift 1 # Remove the action from the arguments
-  TOOL_ARGS=$@
+  TOOL_ARGS=$*
 else
   if [ -z "$1" ]; then
     echo "No action specified."

--- a/projectdo
+++ b/projectdo
@@ -34,17 +34,13 @@ has_command() {
 # evaluates the given command while respecting $QUIET and $DRY_RUN.
 execute() {
   if [ $QUIET = false ]; then
-    if [ -z "$TOOL_ARGS" ]; then
-      printf '%s' "$1"
-    else
-      printf '%s %s' "$1" "$TOOL_ARGS"
-    fi
+    echo "$1" $TOOL_ARGS
   fi
   if [ $DRY_RUN = false ]; then
     if [ $QUIET = false ]; then
-      eval "$1" "$TOOL_ARGS"
+      eval "$1" $TOOL_ARGS
     else
-      eval "$1" "$TOOL_ARGS" > /dev/null
+      eval "$1" $TOOL_ARGS > /dev/null
     fi
   fi
 }
@@ -392,7 +388,8 @@ if [ "$1" = test ] ||
     IS_TOOL=true
   fi
   shift 1 # Remove the action from the arguments
-  TOOL_ARGS=$*
+  # shellcheck disable=SC2124
+  TOOL_ARGS=$@
 else
   if [ -z "$1" ]; then
     echo "No action specified."

--- a/projectdo
+++ b/projectdo
@@ -34,13 +34,13 @@ has_command() {
 # evaluates the given command while respecting $QUIET and $DRY_RUN.
 execute() {
   if [ $QUIET = false ]; then
-    echo "$1" $TOOL_ARGS
+    echo "$1" "$TOOL_ARGS"
   fi
   if [ $DRY_RUN = false ]; then
     if [ $QUIET = false ]; then
-      eval "$1" $TOOL_ARGS
+      eval "$1" "$TOOL_ARGS"
     else
-      eval "$1" $TOOL_ARGS > /dev/null
+      eval "$1" "$TOOL_ARGS" > /dev/null
     fi
   fi
 }
@@ -83,7 +83,7 @@ try_nodejs() {
     echo "Found a package.json file but '$tool' is not installed."
     exit 1
   fi
-  local node_action="$ACTION"
+  node_action="$ACTION"
   # Only the "run" action need translation, the others match 1-to-1
   if [ "$ACTION" = run ]; then
     node_action=start

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,22 +26,6 @@ it() {
   printf "\n  %s" "$1"
 }
 
-trim_string() {
-    # Usage: trim_string "   example   string    "
-
-    # Remove all leading white-space.
-    # '${1%%[![:space:]]*}': Strip everything but leading white-space.
-    # '${1#${XXX}}': Remove the white-space from the start of the string.
-    trim=${1#${1%%[![:space:]]*}}
-
-    # Remove all trailing white-space.
-    # '${trim##*[![:space:]]}': Strip everything but trailing white-space.
-    # '${trim%${XXX}}': Remove the white-space from the end of the string.
-    trim=${trim%${trim##*[![:space:]]}}
-
-    printf '%s' "$trim"
-}
-
 assert() {
   if [ $RUN_EXIT -eq 0 ]; then
     printf " ✓"
@@ -93,129 +77,129 @@ do_print_tool_in() {
 if describe "cargo"; then
   if it "can run build"; then
     do_build_in "cargo"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "cargo build"
+    assertEqual "$RUN_RESULT" "cargo build"
   fi
   if it "can run run"; then
     do_run_in "cargo"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "cargo run"
+    assertEqual "$RUN_RESULT" "cargo run"
   fi
   if it "can run test"; then
     do_test_in "cargo"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "cargo test"
+    assertEqual "$RUN_RESULT" "cargo test"
   fi
   if it "can print tool"; then
     do_print_tool_in "cargo"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "cargo"
+    assertEqual "$RUN_RESULT" "cargo"
   fi
   if it "passes additional arguments to the tool"; then
     RUN_RESULT=$(cd tests/cargo && ../../projectdo -n build --release)
-    assertEqual "$(trim_string "$RUN_RESULT")" "cargo build --release"
+    assertEqual "$RUN_RESULT" "cargo build --release"
   fi
 fi
 
 if describe "stack"; then
   if it "can run build"; then
     do_build_in "stack"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "stack build"
+    assertEqual "$RUN_RESULT" "stack build"
   fi
   if it "can run run"; then
     do_run_in "stack"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "stack run"
+    assertEqual "$RUN_RESULT" "stack run"
   fi
   if it "can run test"; then
     do_test_in "stack"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "stack test"
+    assertEqual "$RUN_RESULT" "stack test"
   fi
   if it "can print tool"; then
     do_print_tool_in "stack"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "stack"
+    assertEqual "$RUN_RESULT" "stack"
   fi
 fi
 
 if describe "npm and yarn"; then
   if it "can run npm build if package.json with build script"; then
     do_build_in "npm"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "npm run build"
+    assertEqual "$RUN_RESULT" "npm run build"
   fi
   if it "can run npm start if package.json with start script"; then
     do_run_in "npm"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "npm start"
+    assertEqual "$RUN_RESULT" "npm start"
   fi
   if it "can run npm test if package.json with test script"; then
     do_test_in "npm"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "npm test"
+    assertEqual "$RUN_RESULT" "npm test"
   fi
   if it "uses yarn file if yarn.lock is present"; then
     do_test_in "yarn"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "yarn test"
+    assertEqual "$RUN_RESULT" "yarn test"
   fi
   if it "does not use npm if package.json contains no test script"; then
     do_test_in "npm-without-test"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "make test"
+    assertEqual "$RUN_RESULT" "make test"
   fi
   if it "can print tool"; then
     do_print_tool_in "npm"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "npm"
+    assertEqual "$RUN_RESULT" "npm"
     do_print_tool_in "yarn"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "yarn"
+    assertEqual "$RUN_RESULT" "yarn"
   fi
 fi
 
 if describe "make"; then
   if it "finds check target"; then
     do_test_in "make-check"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "make check"
+    assertEqual "$RUN_RESULT" "make check"
   fi
   if it "ignores file named check"; then
     do_test_in "make-check-with-check-file"; assertFails
-    assertEqual "$(trim_string "$RUN_RESULT")" "No way to test found :'("
+    assertEqual "$RUN_RESULT" "No way to test found :'("
   fi
   if it "finds check target if both target and file named check"; then
     do_test_in "make-check-with-check-file-and-target"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "make check"
+    assertEqual "$RUN_RESULT" "make check"
   fi
 fi
 
 if describe "go"; then
   if it "finds check target in magefile"; then
     do_test_in "mage"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "mage check"
+    assertEqual "$RUN_RESULT" "mage check"
   fi
 fi
 
 if describe "python"; then
   if it "can build with poetry"; then
     do_build_in "poetry"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "poetry build"
+    assertEqual "$RUN_RESULT" "poetry build"
   fi
   if it "runs pytest with poetry"; then
     do_test_in "poetry"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "poetry run pytest"
+    assertEqual "$RUN_RESULT" "poetry run pytest"
   fi
 fi
 
 if describe "latex"; then
   if it "can build with tectonic"; then
     do_build_in "tectonic"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "tectonic -X build"
+    assertEqual "$RUN_RESULT" "tectonic -X build"
   fi
 fi
 
 if describe "meson"; then
   if it "can build with meson"; then
     do_build_in "meson"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "meson compile"
+    assertEqual "$RUN_RESULT" "meson compile"
   fi
   if it "can test with meson"; then
     do_test_in "meson"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "meson test"
+    assertEqual "$RUN_RESULT" "meson test"
   fi
 fi
 
 if describe "build script"; then
   if it "can build with build script"; then
     do_build_in "build_script"; assert
-    assertEqual "$(trim_string "$RUN_RESULT")" "sh -c build.sh"
+    assertEqual "$RUN_RESULT" "sh -c build.sh"
   fi
 fi
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Colors
-RED=`tput setaf 1`
-BOLD=`tput bold`
-RESET=`tput sgr0`
+RED=$(tput setaf 1)
+BOLD=$(tput bold)
+RESET=$(tput sgr0)
 
 ANY_ERRORS=false
 
@@ -13,17 +13,33 @@ unset MAKELEVEL
 
 # Get the directory of the current script, in a POSIX compatible way
 # https://stackoverflow.com/a/29835459
-script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+script_directory=$(CDPATH="$(cd -- "$(dirname -- "$0")")" && pwd -P)
 
 # Set this variable to ensure top level Makefile doesn't affect the results.
 export PROJECT_ROOT="${script_directory}/tests"
 
 describe() {
-  printf "\n$BOLD$1$RESET"
+  printf "\n%s%s%s" "$BOLD" "$1" "$RESET"
 }
 
 it() {
-  printf "\n  $1"
+  printf "\n  %s" "$1"
+}
+
+trim_string() {
+    # Usage: trim_string "   example   string    "
+
+    # Remove all leading white-space.
+    # '${1%%[![:space:]]*}': Strip everything but leading white-space.
+    # '${1#${XXX}}': Remove the white-space from the start of the string.
+    trim=${1#${1%%[![:space:]]*}}
+
+    # Remove all trailing white-space.
+    # '${trim##*[![:space:]]}': Strip everything but trailing white-space.
+    # '${trim%${XXX}}': Remove the white-space from the end of the string.
+    trim=${trim%${trim##*[![:space:]]}}
+
+    printf '%s' "$trim"
 }
 
 assert() {
@@ -48,153 +64,158 @@ assertEqual() {
   if [ "$1" = "$2" ]; then
     printf " ✓"
   else
-    printf "\n   $BOLD$RED Error:$RESET Expected \"$1\" to equal \"$2\"\n"
+    printf "\n   %s%s Error:%s Expected \"%s\" to equal \"%s\"\n" "$BOLD" "$RED" "$RESET" "$1" "$2"
     ANY_ERRORS=true
   fi
 }
-
-RUN_RESULT=""
 RUN_EXIT=0
 
 do_build_in() {
-  RUN_RESULT=$(cd tests/$1 && ../../projectdo -n build)
+  RUN_RESULT=$(cd tests/"$1" && ../../projectdo -n build)
   RUN_EXIT=$?
 }
 
 do_run_in() {
-  RUN_RESULT=$(cd tests/$1 && ../../projectdo -n run)
+  RUN_RESULT=$(cd tests/"$1" && ../../projectdo -n run)
   RUN_EXIT=$?
 }
 
 do_test_in() {
-  RUN_RESULT=$(cd tests/$1 && ../../projectdo -n test)
+  RUN_RESULT=$(cd tests/"$1" && ../../projectdo -n test)
   RUN_EXIT=$?
 }
 
 do_print_tool_in() {
-  RUN_RESULT=$(cd tests/$1 && ../../projectdo -n tool)
+  RUN_RESULT=$(cd tests/"$1" && ../../projectdo -n tool)
   RUN_EXIT=$?
 }
 
 if describe "cargo"; then
   if it "can run build"; then
     do_build_in "cargo"; assert
-    assertEqual "$RUN_RESULT" "cargo build"
+    assertEqual "$(trim_string "$RUN_RESULT")" "cargo build"
   fi
   if it "can run run"; then
     do_run_in "cargo"; assert
-    assertEqual "$RUN_RESULT" "cargo run"
+    assertEqual "$(trim_string "$RUN_RESULT")" "cargo run"
   fi
   if it "can run test"; then
     do_test_in "cargo"; assert
-    assertEqual "$RUN_RESULT" "cargo test"
+    assertEqual "$(trim_string "$RUN_RESULT")" "cargo test"
   fi
   if it "can print tool"; then
     do_print_tool_in "cargo"; assert
-    assertEqual "$RUN_RESULT" "cargo"
+    assertEqual "$(trim_string "$RUN_RESULT")" "cargo"
   fi
   if it "passes additional arguments to the tool"; then
     RUN_RESULT=$(cd tests/cargo && ../../projectdo -n build --release)
-    assertEqual "$RUN_RESULT" "cargo build --release"
+    assertEqual "$(trim_string "$RUN_RESULT")" "cargo build --release"
   fi
 fi
 
 if describe "stack"; then
   if it "can run build"; then
     do_build_in "stack"; assert
-    assertEqual "$RUN_RESULT" "stack build"
+    assertEqual "$(trim_string "$RUN_RESULT")" "stack build"
   fi
   if it "can run run"; then
     do_run_in "stack"; assert
-    assertEqual "$RUN_RESULT" "stack run"
+    assertEqual "$(trim_string "$RUN_RESULT")" "stack run"
   fi
   if it "can run test"; then
     do_test_in "stack"; assert
-    assertEqual "$RUN_RESULT" "stack test"
+    assertEqual "$(trim_string "$RUN_RESULT")" "stack test"
   fi
   if it "can print tool"; then
     do_print_tool_in "stack"; assert
-    assertEqual "$RUN_RESULT" "stack"
+    assertEqual "$(trim_string "$RUN_RESULT")" "stack"
   fi
 fi
 
 if describe "npm and yarn"; then
   if it "can run npm build if package.json with build script"; then
     do_build_in "npm"; assert
-    assertEqual "$RUN_RESULT" "npm run build"
+    assertEqual "$(trim_string "$RUN_RESULT")" "npm run build"
   fi
   if it "can run npm start if package.json with start script"; then
     do_run_in "npm"; assert
-    assertEqual "$RUN_RESULT" "npm start"
+    assertEqual "$(trim_string "$RUN_RESULT")" "npm start"
   fi
   if it "can run npm test if package.json with test script"; then
     do_test_in "npm"; assert
-    assertEqual "$RUN_RESULT" "npm test"
+    assertEqual "$(trim_string "$RUN_RESULT")" "npm test"
   fi
   if it "uses yarn file if yarn.lock is present"; then
     do_test_in "yarn"; assert
-    assertEqual "$RUN_RESULT" "yarn test"
+    assertEqual "$(trim_string "$RUN_RESULT")" "yarn test"
   fi
   if it "does not use npm if package.json contains no test script"; then
     do_test_in "npm-without-test"; assert
-    assertEqual "$RUN_RESULT" "make test"
+    assertEqual "$(trim_string "$RUN_RESULT")" "make test"
   fi
   if it "can print tool"; then
     do_print_tool_in "npm"; assert
-    assertEqual "$RUN_RESULT" "npm"
+    assertEqual "$(trim_string "$RUN_RESULT")" "npm"
     do_print_tool_in "yarn"; assert
-    assertEqual "$RUN_RESULT" "yarn"
+    assertEqual "$(trim_string "$RUN_RESULT")" "yarn"
   fi
 fi
 
 if describe "make"; then
   if it "finds check target"; then
     do_test_in "make-check"; assert
-    assertEqual "$RUN_RESULT" "make check"
+    assertEqual "$(trim_string "$RUN_RESULT")" "make check"
   fi
   if it "ignores file named check"; then
     do_test_in "make-check-with-check-file"; assertFails
-    assertEqual "$RUN_RESULT" "No way to test found :'("
+    assertEqual "$(trim_string "$RUN_RESULT")" "No way to test found :'("
   fi
   if it "finds check target if both target and file named check"; then
     do_test_in "make-check-with-check-file-and-target"; assert
-    assertEqual "$RUN_RESULT" "make check"
+    assertEqual "$(trim_string "$RUN_RESULT")" "make check"
   fi
 fi
 
 if describe "go"; then
   if it "finds check target in magefile"; then
     do_test_in "mage"; assert
-    assertEqual "$RUN_RESULT" "mage check"
+    assertEqual "$(trim_string "$RUN_RESULT")" "mage check"
   fi
 fi
 
 if describe "python"; then
   if it "can build with poetry"; then
     do_build_in "poetry"; assert
-    assertEqual "$RUN_RESULT" "poetry build"
+    assertEqual "$(trim_string "$RUN_RESULT")" "poetry build"
   fi
   if it "runs pytest with poetry"; then
     do_test_in "poetry"; assert
-    assertEqual "$RUN_RESULT" "poetry run pytest"
+    assertEqual "$(trim_string "$RUN_RESULT")" "poetry run pytest"
   fi
 fi
 
 if describe "latex"; then
   if it "can build with tectonic"; then
     do_build_in "tectonic"; assert
-    assertEqual "$RUN_RESULT" "tectonic -X build"
+    assertEqual "$(trim_string "$RUN_RESULT")" "tectonic -X build"
   fi
 fi
 
 if describe "meson"; then
   if it "can build with meson"; then
     do_build_in "meson"; assert
-    assertEqual "$RUN_RESULT" "meson compile"
+    assertEqual "$(trim_string "$RUN_RESULT")" "meson compile"
   fi
   if it "can test with meson"; then
     do_test_in "meson"; assert
-    assertEqual "$RUN_RESULT" "meson test"
+    assertEqual "$(trim_string "$RUN_RESULT")" "meson test"
+  fi
+fi
+
+if describe "build script"; then
+  if it "can build with build script"; then
+    do_build_in "build_script"; assert
+    assertEqual "$(trim_string "$RUN_RESULT")" "sh -c build.sh"
   fi
 fi
 

--- a/tests/build_script/build.sh
+++ b/tests/build_script/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Build successful"


### PR DESCRIPTION
Sometimes I have projects that don't require tooling systems to be present in the repository but I do need a build step, that's where a `build.sh` comes in. I've seen this in other people's projects too so this would be a nice feature to merge.

I also took care of some low hanging fruit by fixing errors thrown by [ShellCheck](https://www.shellcheck.net/), thereby achieving POSIX compliance.

Makefile was also expanded to include `install` and `uninstall` targets to make it easier to do those things.

All tests pass and I also added one for `build.sh`.

I can also add support for `.bat` and `.ps1` scripts.

There could also be a `tests.sh` or something like that that could be supported to have a generic way to build/run/test smaller projects.