### PR TITLE
feat: ✨ introduce support for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ request.
 | Meson        | C, C++, etc.     | `meson.build`                              | `meson compile` <br/> run n/a <br/> `meson test`       |
 | npm          | JavaScript, etc. | `package.json`                             | `npm build` <br/> `npm start` <br/> `npm test`         |
 | yarn         | JavaScript, etc. | `package.json` and `yarn.lock`             | `yarn build` <br/> `yarn start` <br/> `yarn test`      |
+| pnpm         | JavaScript, etc  | `package.json` and `pnpm-lock.yaml`        | `pnpm build` <br/> `pnpm start` <br/> `pnpm test`      |
 | Maven        | Java, etc.       | `pom.xml`                                  | `mvn compile` <br/> run n/a <br/> `mvn test`           |
 | Leiningen    | Clojure          | `project.clj`                              | `lein test`                                            |
 | Cabal        | Haskell          | `*.cabal`                                  | `cabal build` <br/> `cabal run` <br/> `cabal test`     |

--- a/projectdo
+++ b/projectdo
@@ -76,6 +76,8 @@ try_nodejs() {
   fi
   if [ -f yarn.lock ]; then
     tool=yarn
+  elif [ -f pnpm-lock.yaml ]; then
+    tool=pnpm
   else
     tool=npm
   fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -116,7 +116,7 @@ if describe "stack"; then
   fi
 fi
 
-if describe "npm and yarn"; then
+if describe "npm / yarn / pnpm"; then
   if it "can run npm build if package.json with build script"; then
     do_build_in "npm"; assert
     assertEqual "$RUN_RESULT" "npm run build"
@@ -129,9 +129,25 @@ if describe "npm and yarn"; then
     do_test_in "npm"; assert
     assertEqual "$RUN_RESULT" "npm test"
   fi
-  if it "uses yarn file if yarn.lock is present"; then
+  if it "uses yarn if yarn.lock is present"; then
     do_test_in "yarn"; assert
     assertEqual "$RUN_RESULT" "yarn test"
+  fi
+  if it "uses pnpm if pnpm-lock.yaml is present"; then
+    do_test_in "pnpm"; assert
+    assertEqual "$RUN_RESULT" "pnpm test"
+  fi
+  if it "can run pnpm build if package.json with build script"; then
+    do_build_in "pnpm"; assert
+    assertEqual "$RUN_RESULT" "pnpm run build"
+  fi
+  if it "can run pnpm start if package.json with start script"; then
+    do_run_in "pnpm"; assert
+    assertEqual "$RUN_RESULT" "pnpm start"
+  fi
+  if it "can run pnpm test if package.json with test script"; then
+    do_test_in "pnpm"; assert
+    assertEqual "$RUN_RESULT" "pnpm test"
   fi
   if it "does not use npm if package.json contains no test script"; then
     do_test_in "npm-without-test"; assert
@@ -142,6 +158,8 @@ if describe "npm and yarn"; then
     assertEqual "$RUN_RESULT" "npm"
     do_print_tool_in "yarn"; assert
     assertEqual "$RUN_RESULT" "yarn"
+    do_print_tool_in "pnpm"; assert
+    assertEqual "$RUN_RESULT" "pnpm"
   fi
 fi
 

--- a/tests/pnpm/package.json
+++ b/tests/pnpm/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "echo \"Error: no build specified\" && exit 1",
+    "start": "echo \"Error: no start specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
## Description:
This pull request introduces support for [pnpm](https://pnpm.io/) in `projectdo`. Previously, `projectdo` supported only `npm` and `yarn`, which meant that when `projectdo` was run in a project using pnpm, it would default to running npm instead.

Key changes include:

- Detection of pnpm through the presence of the `pnpm-lock.yaml` file.
- Adherence to the existing pattern for package manager detection to maintain consistency.

> [!NOTE]
> While adding support for pnpm in Projectdo, it's worth mentioning that the `packageManager` directive in the `package.json` file can be used to specify the package manager for the project. This directive provides a more standardized approach to identifying the package manager compared to inspecting specific lock files. For more details, refer to the official documentation [here](https://nodejs.org/api/packages.html#packagemanager).

> [!WARNING]
> Apologies for any unwanted changes due to my editor's auto-formatting. Please let me know if any adjustments are needed, and I'll revert them.
