### PR TITLE
fix: can't run tests in projectdo without `npm` installed

### DIFF
--- a/projectdo
+++ b/projectdo
@@ -323,6 +323,8 @@ try_build_script() {
 # End of list of tools
 
 detect_and_run() {
+  try_justfile
+  try_makefile
   try_nodejs
   try_cargo
   try_stack
@@ -331,8 +333,6 @@ detect_and_run() {
   try_cmake
   try_maven
   try_lein
-  try_justfile
-  try_makefile
   try_python
   try_go
   try_latex

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -195,6 +195,10 @@ if describe "make"; then
     do_test_in "make-check-with-check-file-and-target"; assert
     assertEqual "$RUN_RESULT" "make check"
   fi
+  if it "finds check target despite package.json"; then
+    do_test_in "make-with-npm"; assert
+    assertEqual "$RUN_RESULT" "make check"
+  fi
 fi
 
 if describe "go"; then

--- a/tests/make-with-npm/Makefile
+++ b/tests/make-with-npm/Makefile
@@ -1,0 +1,2 @@
+check:
+	@echo "Tests passed."

--- a/tests/make-with-npm/package.json
+++ b/tests/make-with-npm/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "echo \"Error: no build specified\" && exit 1",
+    "start": "echo \"Error: no start specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
fixes #24