### PR TITLE
build: fix pandoc check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	@cp -p man/$(BINARY_NAME).1 $(DESTDIR)$(MANDIR)/man1
 
 manpage:
-	@if [ -n $(command -v pandoc) ]; then \
+	@if [ -n "$(command -v pandoc)" ]; then \
 		pandoc -s -t man man/$(BINARY_NAME).1.md -o man/$(BINARY_NAME).1; \
 		echo "SUCCESS: manpage generated"; \
 	else \


### PR DESCRIPTION
I don't have pandoc installed normally and the check doesn't work properly, leading to this error message:

```sh-session
$ make manpage
/bin/sh: line 1: pandoc: command not found
SUCCESS: manpage generated
```

After this change, the check works as expected:

```sh-session
$ make manpage
ERROR: could not generate manpage. Pandoc not found.
```