### PR TITLE
Formatting and shellcheck

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[{projectdo,*.sh,*.fish,project.json,tests/**}]
+indent_size = 2
+indent_style = space
+
+[{Makefile,justfile}]
+indent_style = tab

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,19 +2,19 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install tools used in tests
-      run: |
-        sudo apt install -y just nix-bin gradle
-        npm install -g pnpm
-        npm install -g bun
-    - name: Run tests
-      run: dash run-tests.sh
+      - uses: actions/checkout@v4
+      - name: Install tools used in tests
+        run: |
+          sudo apt install -y just nix-bin gradle
+          npm install -g pnpm
+          npm install -g bun
+      - name: Run tests
+        run: dash run-tests.sh

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check shell files
+        uses: luizm/action-sh-checker@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sh_checker_only_diff: true
+          sh_checker_comment: true
       - name: Install tools used in tests
         run: |
           sudo apt install -y just nix-bin gradle

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,10 @@ uninstall:
 
 test:
 	sh run-tests.sh
+
+format:
+	@if [ -n "$(shell command -v shfmt)" ]; then \
+		shfmt -w projectdo run-tests.sh; \
+	else \
+		echo "ERROR: could not format scripts. shfmt not found."; \
+	fi

--- a/projectdo
+++ b/projectdo
@@ -23,7 +23,7 @@ QUIET=false
 DRY_RUN=false
 PROJECT_ROOT="${PROJECT_ROOT:-}"
 ACTION=""
-TOOL_ARGS="" # Arguments to pass along to the tool
+TOOL_ARGS=""  # Arguments to pass along to the tool
 IS_TOOL=false # True if ACTION is 'tool' as this action is somewhat special.
 
 has_command() {
@@ -40,7 +40,7 @@ execute() {
     if [ $QUIET = false ]; then
       eval "$1" $TOOL_ARGS
     else
-      eval "$1" $TOOL_ARGS > /dev/null
+      eval "$1" $TOOL_ARGS >/dev/null
     fi
   fi
 }
@@ -89,8 +89,7 @@ go_up() {
 # directory and not right next to the `package.json` file. This is handled by
 # looking up the directory hierarchy.
 detect_nodejs_tool() {
-  while :
-  do
+  while :; do
     # echo looking for nodejs tool
     if [ -f package-lock.json ]; then
       echo yarn
@@ -154,15 +153,18 @@ try_cargo() {
 try_meson() {
   if [ -f meson.build ]; then
     case $ACTION in
-      build)
-        execute "meson compile"
-        exit ;;
-      test)
-        execute "meson test"
-        exit ;;
-      run)
-        echo "projectdo does not know how to run a project with Meson."
-        exit
+    build)
+      execute "meson compile"
+      exit
+      ;;
+    test)
+      execute "meson test"
+      exit
+      ;;
+    run)
+      echo "projectdo does not know how to run a project with Meson."
+      exit
+      ;;
     esac
   fi
 }
@@ -191,7 +193,7 @@ try_stack() {
 # Haskell + Cabal
 
 try_cabal() {
-  cabal_file="$(find ./ -maxdepth 1 -name "*.cabal" 2> /dev/null | wc -l)"
+  cabal_file="$(find ./ -maxdepth 1 -name "*.cabal" 2>/dev/null | wc -l)"
   if [ "$cabal_file" -gt 0 ] && [ ! -f stack.yml ]; then
     execute_command cabal "$ACTION"
   fi
@@ -202,15 +204,18 @@ try_cabal() {
 try_maven() {
   if [ -f pom.xml ]; then
     case $ACTION in
-      build)
-        execute "mvn compile"
-        exit ;;
-      test)
-        execute "mvn test"
-        exit ;;
-      run)
-        echo "projectdo does not know how to run a project with Maven."
-        exit
+    build)
+      execute "mvn compile"
+      exit
+      ;;
+    test)
+      execute "mvn test"
+      exit
+      ;;
+    run)
+      echo "projectdo does not know how to run a project with Maven."
+      exit
+      ;;
     esac
   fi
 }
@@ -220,15 +225,18 @@ try_maven() {
 try_gradle() {
   if [ -f build.gradle ] || [ -f build.gradle.kts ]; then
     case $ACTION in
-      build)
-        execute "gradle build"
-        exit ;;
-      test)
-        execute "gradle test"
-        exit ;;
-      run)
-        echo "projectdo does not know how to run a project with Gradle."
-        exit ;;
+    build)
+      execute "gradle build"
+      exit
+      ;;
+    test)
+      execute "gradle test"
+      exit
+      ;;
+    run)
+      echo "projectdo does not know how to run a project with Gradle."
+      exit
+      ;;
     esac
   fi
 }
@@ -256,23 +264,23 @@ try_justfile() {
 # Makefile
 
 has_make_target() {
-    target="${1?}"
-    output=$(make -n "${target}" 2>&1)
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-        return $exit_code
-    fi
+  target="${1?}"
+  output=$(make -n "${target}" 2>&1)
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    return $exit_code
+  fi
 
-    # If there is a file with the name of the target we're looking for but no
-    # actual target with that name, make will exit successfully with that
-    # message. We need to consider that case as a "target not found". Note that
-    # the way the target is quoted in the output (`test' vs 'test') can differ
-    # across OSes so we only check a prefix up to the problematic quotes.
-    if expr "$output" : "make: Nothing to be done for" 1> /dev/null; then
-        return 1
-    fi
+  # If there is a file with the name of the target we're looking for but no
+  # actual target with that name, make will exit successfully with that
+  # message. We need to consider that case as a "target not found". Note that
+  # the way the target is quoted in the output (`test' vs 'test') can differ
+  # across OSes so we only check a prefix up to the problematic quotes.
+  if expr "$output" : "make: Nothing to be done for" 1>/dev/null; then
+    return 1
+  fi
 
-    return 0
+  return 0
 }
 
 try_makefile() {
@@ -339,34 +347,41 @@ try_python() {
   if [ -f pyproject.toml ]; then
     if grep -q -m 1 "^\[tool.poetry\]$" pyproject.toml; then
       case $ACTION in
-        build)
-          execute "poetry build"
-          exit ;;
-        test)
-          # TODO: There are other Python test frameworks, it would be nice to
-          # detect and run the right one.
-          execute "poetry run pytest"
-          exit ;;
-        run)
-          echo "projectdo does not know how to run a project with Poetry."
-          exit
-      esac
-    else if [ -f uv.lock ]; then
-      case $ACTION in
-        build)
-          echo "projectdo does not know how to run a project with uv."
-          exit ;;
-        test)
-          echo "projectdo does not know how to run a project with uv."
-          exit ;;
-        run)
-          execute "uv run"
-          exit ;;
+      build)
+        execute "poetry build"
+        exit
+        ;;
+      test)
+        # TODO: There are other Python test frameworks, it would be nice to
+        # detect and run the right one.
+        execute "poetry run pytest"
+        exit
+        ;;
+      run)
+        echo "projectdo does not know how to run a project with Poetry."
+        exit
+        ;;
       esac
     else
-      echo "Found a pyproject.toml file but projectdo is not sure how to run it."
-      exit
-    fi
+      if [ -f uv.lock ]; then
+        case $ACTION in
+        build)
+          echo "projectdo does not know how to run a project with uv."
+          exit
+          ;;
+        test)
+          echo "projectdo does not know how to run a project with uv."
+          exit
+          ;;
+        run)
+          execute "uv run"
+          exit
+          ;;
+        esac
+      else
+        echo "Found a pyproject.toml file but projectdo is not sure how to run it."
+        exit
+      fi
     fi
     return 1
   fi
@@ -403,8 +418,8 @@ try_go() {
 
 try_latex() {
   if [ -f Tectonic.toml ] && [ "$ACTION" = build ]; then
-      execute "tectonic -X build"
-      exit
+    execute "tectonic -X build"
+    exit
   fi
 }
 
@@ -460,7 +475,7 @@ set_project_root() {
     # git submodule then the root of the outer git repo is used. If we're not
     # in a git repo the git command will not output anything and $PROJECT_ROOT
     # is set to the empty string which is fine.
-    PROJECT_ROOT=$(git rev-parse --show-superproject-working-tree --show-toplevel 2> /dev/null | head -n 1)
+    PROJECT_ROOT=$(git rev-parse --show-superproject-working-tree --show-toplevel 2>/dev/null | head -n 1)
   fi
 }
 
@@ -491,32 +506,46 @@ Tool arguments:
 
 # Main execution starts here
 
-while getopts dhnqv-: c
-do
+while getopts dhnqv-: c; do
   case $c in
-    d) DRY_RUN=true ;;
-    h) display_help; exit 0 ;;
-    n) DRY_RUN=true ;;
-    q) QUIET=true ;;
-    v) display_version; exit 0 ;;
-    -) case $OPTARG in
-         help) display_help; exit 0 ;;
-         dry-run) DRY_RUN=true ;;
-         quiet) QUIET=true ;;
-         version) display_version; exit 0 ;;
-         '' ) break ;; # "--" should terminate argument processing
-         * ) echo "Illegal option --$OPTARG" >&2; exit 1 ;;
-      esac ;;
-    \?) exit 1 ;;
+  d) DRY_RUN=true ;;
+  h)
+    display_help
+    exit 0
+    ;;
+  n) DRY_RUN=true ;;
+  q) QUIET=true ;;
+  v)
+    display_version
+    exit 0
+    ;;
+  -) case $OPTARG in
+    help)
+      display_help
+      exit 0
+      ;;
+    dry-run) DRY_RUN=true ;;
+    quiet) QUIET=true ;;
+    version)
+      display_version
+      exit 0
+      ;;
+    '') break ;; # "--" should terminate argument processing
+    *)
+      echo "Illegal option --$OPTARG" >&2
+      exit 1
+      ;;
+    esac ;;
+  \?) exit 1 ;;
   esac
 done
 
-shift $((OPTIND-1)) # Shift away the parsed option arguments
+shift $((OPTIND - 1)) # Shift away the parsed option arguments
 
 if [ "$1" = test ] ||
-   [ "$1" = run ] ||
-   [ "$1" = build ] ||
-   [ "$1" = tool ]; then
+  [ "$1" = run ] ||
+  [ "$1" = build ] ||
+  [ "$1" = tool ]; then
   ACTION=$1
   if [ "$1" = tool ]; then
     IS_TOOL=true
@@ -539,8 +568,7 @@ fi
 
 set_project_root
 
-while :
-do
+while :; do
   detect_and_run
   # If we didn't detect a tool to run in this directory we go up one directory
   if ! go_up; then

--- a/projectdo
+++ b/projectdo
@@ -32,6 +32,7 @@ has_command() {
 
 # When running the appropriate external tool this function is used which
 # evaluates the given command while respecting $QUIET and $DRY_RUN.
+# shellcheck disable=SC2086
 execute() {
   if [ $QUIET = false ]; then
     echo "$1" $TOOL_ARGS
@@ -116,7 +117,7 @@ try_nodejs() {
     return 1
   fi
   tool=$(detect_nodejs_tool)
-  if ! has_command $tool; then
+  if ! has_command "$tool"; then
     echo "Found a package.json file but '$tool' is not installed."
     exit 1
   fi
@@ -319,7 +320,7 @@ try_nix_flake() {
       execute "nix flake check"
       exit
     else
-      execute_command nix $ACTION
+      execute_command nix "$ACTION"
     fi
   fi
   return 1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -76,19 +76,23 @@ do_print_tool_in() {
 
 if describe "cargo"; then
   if it "can run build"; then
-    do_build_in "cargo"; assert
+    do_build_in "cargo"
+    assert
     assertEqual "$RUN_RESULT" "cargo build"
   fi
   if it "can run run"; then
-    do_run_in "cargo"; assert
+    do_run_in "cargo"
+    assert
     assertEqual "$RUN_RESULT" "cargo run"
   fi
   if it "can run test"; then
-    do_test_in "cargo"; assert
+    do_test_in "cargo"
+    assert
     assertEqual "$RUN_RESULT" "cargo test"
   fi
   if it "can print tool"; then
-    do_print_tool_in "cargo"; assert
+    do_print_tool_in "cargo"
+    assert
     assertEqual "$RUN_RESULT" "cargo"
   fi
   if it "passes additional arguments to the tool"; then
@@ -99,273 +103,332 @@ fi
 
 if describe "stack"; then
   if it "can run build"; then
-    do_build_in "stack"; assert
+    do_build_in "stack"
+    assert
     assertEqual "$RUN_RESULT" "stack build"
   fi
   if it "can run run"; then
-    do_run_in "stack"; assert
+    do_run_in "stack"
+    assert
     assertEqual "$RUN_RESULT" "stack run"
   fi
   if it "can run test"; then
-    do_test_in "stack"; assert
+    do_test_in "stack"
+    assert
     assertEqual "$RUN_RESULT" "stack test"
   fi
   if it "can print tool"; then
-    do_print_tool_in "stack"; assert
+    do_print_tool_in "stack"
+    assert
     assertEqual "$RUN_RESULT" "stack"
   fi
 fi
 
 if describe "npm / yarn / pnpm / bun"; then
   if it "can run npm build if package.json with build script"; then
-    do_build_in "npm"; assert
+    do_build_in "npm"
+    assert
     assertEqual "$RUN_RESULT" "npm run build"
   fi
   if it "can run npm start if package.json with start script"; then
-    do_run_in "npm"; assert
+    do_run_in "npm"
+    assert
     assertEqual "$RUN_RESULT" "npm start"
   fi
   if it "can run npm test if package.json with test script"; then
-    do_test_in "npm"; assert
+    do_test_in "npm"
+    assert
     assertEqual "$RUN_RESULT" "npm test"
   fi
   if it "uses yarn if yarn.lock is present"; then
-    do_test_in "yarn"; assert
+    do_test_in "yarn"
+    assert
     assertEqual "$RUN_RESULT" "yarn test"
   fi
   if it "uses pnpm if pnpm-lock.yaml is present"; then
-    do_test_in "pnpm"; assert
+    do_test_in "pnpm"
+    assert
     assertEqual "$RUN_RESULT" "pnpm test"
   fi
   if it "uses bun if bun.lock is present"; then
-    do_test_in "bun"; assert
+    do_test_in "bun"
+    assert
     assertEqual "$RUN_RESULT" "bun test"
   fi
   if it "uses bun if bun.lockb is present"; then
-    do_test_in "bun-lockb"; assert
+    do_test_in "bun-lockb"
+    assert
     assertEqual "$RUN_RESULT" "bun test"
   fi
   if it "can run bun build if package.json with build script"; then
-    do_build_in "bun"; assert
+    do_build_in "bun"
+    assert
     assertEqual "$RUN_RESULT" "bun run build"
   fi
   if it "can run bun start if package.json with start script"; then
-    do_run_in "bun"; assert
+    do_run_in "bun"
+    assert
     assertEqual "$RUN_RESULT" "bun start"
   fi
   if it "can run bun test if package.json with test script"; then
-    do_test_in "bun"; assert
+    do_test_in "bun"
+    assert
     assertEqual "$RUN_RESULT" "bun test"
   fi
   if it "can run pnpm build if package.json with build script"; then
-    do_build_in "pnpm"; assert
+    do_build_in "pnpm"
+    assert
     assertEqual "$RUN_RESULT" "pnpm run build"
   fi
   if it "can run pnpm start if package.json with start script"; then
-    do_run_in "pnpm"; assert
+    do_run_in "pnpm"
+    assert
     assertEqual "$RUN_RESULT" "pnpm start"
   fi
   if it "can run pnpm test if package.json with test script"; then
-    do_test_in "pnpm"; assert
+    do_test_in "pnpm"
+    assert
     assertEqual "$RUN_RESULT" "pnpm test"
   fi
   if it "does not use npm if package.json contains no test script"; then
-    do_test_in "npm-without-test"; assert
+    do_test_in "npm-without-test"
+    assert
     assertEqual "$RUN_RESULT" "make test"
   fi
   if it "can print tool"; then
-    do_print_tool_in "npm"; assert
+    do_print_tool_in "npm"
+    assert
     assertEqual "$RUN_RESULT" "npm"
-    do_print_tool_in "yarn"; assert
+    do_print_tool_in "yarn"
+    assert
     assertEqual "$RUN_RESULT" "yarn"
-    do_print_tool_in "pnpm"; assert
+    do_print_tool_in "pnpm"
+    assert
     assertEqual "$RUN_RESULT" "pnpm"
-    do_print_tool_in "bun"; assert
+    do_print_tool_in "bun"
+    assert
     assertEqual "$RUN_RESULT" "bun"
   fi
   if it "detects yarn in workspace setup"; then
-    do_print_tool_in "yarn-workspace/workspace-a"; assert
+    do_print_tool_in "yarn-workspace/workspace-a"
+    assert
     assertEqual "$RUN_RESULT" "yarn"
-    do_print_tool_in "yarn-workspace/workspace-b"; assert
+    do_print_tool_in "yarn-workspace/workspace-b"
+    assert
     assertEqual "$RUN_RESULT" "yarn"
   fi
 fi
 
 if describe "just"; then
   if it "finds test target"; then
-    do_test_in "just"; assert
+    do_test_in "just"
+    assert
     assertEqual "$RUN_RESULT" "just test"
   fi
   if it "finds build target"; then
-    do_build_in "just"; assert
+    do_build_in "just"
+    assert
     assertEqual "$RUN_RESULT" "just build"
   fi
   if it "finds run target"; then
-    do_run_in "just"; assert
+    do_run_in "just"
+    assert
     assertEqual "$RUN_RESULT" "just run"
   fi
   if it "can print tool"; then
-    do_print_tool_in "just"; assert
+    do_print_tool_in "just"
+    assert
     assertEqual "$RUN_RESULT" "just"
   fi
 fi
 
 if describe "make"; then
   if it "finds check target"; then
-    do_test_in "make-check"; assert
+    do_test_in "make-check"
+    assert
     assertEqual "$RUN_RESULT" "make check"
   fi
   if it "ignores file named check"; then
-    do_test_in "make-check-with-check-file"; assertFails
+    do_test_in "make-check-with-check-file"
+    assertFails
     assertEqual "$RUN_RESULT" "No way to test found :'("
   fi
   if it "finds check target if both target and file named check"; then
-    do_test_in "make-check-with-check-file-and-target"; assert
+    do_test_in "make-check-with-check-file-and-target"
+    assert
     assertEqual "$RUN_RESULT" "make check"
   fi
   if it "finds check target despite package.json"; then
-    do_test_in "make-with-npm"; assert
+    do_test_in "make-with-npm"
+    assert
     assertEqual "$RUN_RESULT" "make check"
   fi
 fi
 
 if describe "nix-flake"; then
   if it "can build with nix"; then
-    do_build_in "nix-flake"; assert
+    do_build_in "nix-flake"
+    assert
     assertEqual "$RUN_RESULT" "nix build"
   fi
   if it "can run with nix"; then
-    do_run_in "nix-flake"; assert
+    do_run_in "nix-flake"
+    assert
     assertEqual "$RUN_RESULT" "nix run"
   fi
   if it "can test with nix"; then
-    do_test_in "nix-flake"; assert
+    do_test_in "nix-flake"
+    assert
     assertEqual "$RUN_RESULT" "nix flake check"
   fi
 fi
 
 if describe "nix"; then
   if it "can build with nix-build"; then
-    do_build_in "nix"; assert
+    do_build_in "nix"
+    assert
     assertEqual "$RUN_RESULT" "nix-build"
   fi
 fi
 
 if describe "go"; then
   if it "finds check target in magefile"; then
-    do_test_in "mage"; assert
+    do_test_in "mage"
+    assert
     assertEqual "$RUN_RESULT" "mage check"
   fi
   if it "runs go test without magefile"; then
-    do_test_in "go"; assert
+    do_test_in "go"
+    assert
     assertEqual "$RUN_RESULT" "go test"
   fi
   if it "can run go run"; then
-    do_run_in "go"; assert
+    do_run_in "go"
+    assert
     assertEqual "$RUN_RESULT" "go run"
   fi
   if it "can run go build"; then
-    do_build_in "go"; assert
+    do_build_in "go"
+    assert
     assertEqual "$RUN_RESULT" "go build"
   fi
   if it "can print tool"; then
-    do_print_tool_in "go"; assert
+    do_print_tool_in "go"
+    assert
     assertEqual "$RUN_RESULT" "go"
   fi
 fi
 
 if describe "python"; then
   if it "can build with poetry"; then
-    do_build_in "poetry"; assert
+    do_build_in "poetry"
+    assert
     assertEqual "$RUN_RESULT" "poetry build"
   fi
   if it "runs pytest with poetry"; then
-    do_test_in "poetry"; assert
+    do_test_in "poetry"
+    assert
     assertEqual "$RUN_RESULT" "poetry run pytest"
   fi
   if it "can run with uv"; then
-    do_run_in "uv"; assert
+    do_run_in "uv"
+    assert
     assertEqual "$RUN_RESULT" "uv run"
   fi
 fi
 
 if describe "latex"; then
   if it "can build with tectonic"; then
-    do_build_in "tectonic"; assert
+    do_build_in "tectonic"
+    assert
     assertEqual "$RUN_RESULT" "tectonic -X build"
   fi
 fi
 
 if describe "meson"; then
   if it "can build with meson"; then
-    do_build_in "meson"; assert
+    do_build_in "meson"
+    assert
     assertEqual "$RUN_RESULT" "meson compile"
   fi
   if it "can test with meson"; then
-    do_test_in "meson"; assert
+    do_test_in "meson"
+    assert
     assertEqual "$RUN_RESULT" "meson test"
   fi
 fi
 
 if describe "gradle"; then
   if it "can build with gradle"; then
-    do_build_in "gradle"; assert
+    do_build_in "gradle"
+    assert
     assertEqual "$RUN_RESULT" "gradle build"
   fi
   if it "can test with gradle"; then
-    do_test_in "gradle"; assert
+    do_test_in "gradle"
+    assert
     assertEqual "$RUN_RESULT" "gradle test"
   fi
 fi
 
 if describe "dotnet csproj"; then
   if it "can build with dotnet"; then
-    do_build_in "dotnet-csproj"; assert
+    do_build_in "dotnet-csproj"
+    assert
     assertEqual "$RUN_RESULT" "dotnet build"
   fi
   if it "can run with dotnet"; then
-    do_run_in "dotnet-csproj"; assert
+    do_run_in "dotnet-csproj"
+    assert
     assertEqual "$RUN_RESULT" "dotnet run"
   fi
   if it "can test with dotnet"; then
-    do_test_in "dotnet-csproj"; assert
+    do_test_in "dotnet-csproj"
+    assert
     assertEqual "$RUN_RESULT" "dotnet test"
   fi
 fi
 
 if describe "dotnet fsproj"; then
   if it "can build with dotnet"; then
-    do_build_in "dotnet-fsproj"; assert
+    do_build_in "dotnet-fsproj"
+    assert
     assertEqual "$RUN_RESULT" "dotnet build"
   fi
   if it "can run with dotnet"; then
-    do_run_in "dotnet-fsproj"; assert
+    do_run_in "dotnet-fsproj"
+    assert
     assertEqual "$RUN_RESULT" "dotnet run"
   fi
   if it "can test with dotnet"; then
-    do_test_in "dotnet-fsproj"; assert
+    do_test_in "dotnet-fsproj"
+    assert
     assertEqual "$RUN_RESULT" "dotnet test"
   fi
 fi
 
 if describe "dotnet sln"; then
   if it "can build with dotnet"; then
-    do_build_in "dotnet-sln"; assert
+    do_build_in "dotnet-sln"
+    assert
     assertEqual "$RUN_RESULT" "dotnet build"
   fi
   if it "can run with dotnet"; then
-    do_run_in "dotnet-sln"; assert
+    do_run_in "dotnet-sln"
+    assert
     assertEqual "$RUN_RESULT" "dotnet run"
   fi
   if it "can test with dotnet"; then
-    do_test_in "dotnet-sln"; assert
+    do_test_in "dotnet-sln"
+    assert
     assertEqual "$RUN_RESULT" "dotnet test"
   fi
 fi
 
 if describe "build script"; then
   if it "can build with build script"; then
-    do_build_in "build_script"; assert
+    do_build_in "build_script"
+    assert
     assertEqual "$RUN_RESULT" "sh -c build.sh"
   fi
 fi


### PR DESCRIPTION
Specify formatting #26, re-format and apply shellcheck fixes.

I'm not sure if some automated formatting tool should be set up (how to declare that it should be installed?) or if we assume the user will set up their editor correctly and CI catches any mistakes.

I could go further with tools like [direnv](http://direnv.net), [treefmt](https://treefmt.com/latest/) and [pre-commit](https://pre-commit.com), but I haven't used the latter two outside of nix, which has easy wrappers for both tools there and handles installing the underlying tools in a way that doesn't affect the rest of the system. Therefore, it might be a fair bit of work. If that's desired, perhaps we could tackle that in another issue?