### PR TITLE
[Feature] Allow assigning package scripts to missing actions

### DIFF
--- a/projectdo
+++ b/projectdo
@@ -22,6 +22,7 @@ VERSION="1.0.1"
 QUIET=false
 DRY_RUN=false
 PROJECT_ROOT="${PROJECT_ROOT:-}"
+START_DIR=""
 ACTION=""
 TOOL_ARGS=""  # Arguments to pass along to the tool
 IS_TOOL=false # True if ACTION is 'tool' as this action is somewhat special.
@@ -98,6 +99,47 @@ execute_command() {
   exit 0
 }
 
+projectdo_config_dir() {
+  if [ -n "$PROJECTDO_CONFIG_DIR" ]; then
+    echo "$PROJECTDO_CONFIG_DIR"
+  else
+    echo "$HOME/.projectdo"
+  fi
+}
+
+project_config_file() {
+  project_dir="${1?}"
+  project_name=$(printf "%s" "$(basename "$project_dir")" | tr -c 'A-Za-z0-9._-' '_')
+  config_key=$(printf "%s" "$project_dir" | cksum | awk '{print $1}')
+  echo "$(projectdo_config_dir)/projects/$project_name-$config_key.conf"
+}
+
+read_action_script_assignment() {
+  project_dir="${1?}"
+  config_file=$(project_config_file "$project_dir")
+
+  if [ -f "$config_file" ]; then
+    sed -n "s/^${ACTION}=//p" "$config_file" | head -n 1
+  fi
+}
+
+write_action_script_assignment() {
+  project_dir="${1?}"
+  script="${2?}"
+  config_file=$(project_config_file "$project_dir")
+  config_dir=$(dirname "$config_file")
+
+  mkdir -p "$config_dir" || exit 1
+  {
+    echo "project_dir=$project_dir"
+    if [ -f "$config_file" ]; then
+      grep -v "^project_dir=" "$config_file" | grep -v "^${ACTION}=" 2>/dev/null
+    fi
+    echo "$ACTION=$script"
+  } >"$config_file.tmp" || exit 1
+  mv "$config_file.tmp" "$config_file" || exit 1
+}
+
 # Navigate up one directory. The command is successful if this is possible
 # without leaving the current project, entering the home directory, or entering
 # the root directory.
@@ -155,7 +197,9 @@ try_nodejs() {
   if [ ! -f package.json ]; then
     return 1
   fi
+  package_dir="$PWD"
   tool=$(detect_nodejs_tool)
+  cd "$package_dir" || return 1
   has_command_or_error "$tool" package.json
   node_action=$(translate_action build run=start test)
   # We check if the package.json file contains an appropriate script. We use
@@ -163,6 +207,13 @@ try_nodejs() {
   # could've used `npm run` to get the authorative list of the scripts but
   # invoking `npm` is two orders of magnitude slower which leads to a
   # noticeable delay.
+  if ! $IS_TOOL; then
+    assigned_script=$(read_action_script_assignment "$package_dir")
+    if [ -n "$assigned_script" ] && grep -q "^[[:space:]]*\"${assigned_script}\":" package.json; then
+      execute_command "$tool" "run $assigned_script"
+    fi
+  fi
+
   if ! $IS_TOOL && ! grep -q "^[[:space:]]*\"${node_action}\":" package.json; then
     return 0
   fi
@@ -171,6 +222,86 @@ try_nodejs() {
   else
     execute_command "$tool" "$node_action"
   fi
+}
+
+list_package_scripts() {
+  package_json="${1?}"
+
+  if has_command node; then
+    node -e '
+const fs = require("fs");
+const packageJson = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+for (const script of Object.keys(packageJson.scripts || {})) {
+  console.log(script);
+}
+' "$package_json" 2>/dev/null
+  else
+    sed -n '/"scripts"[[:space:]]*:[[:space:]]*{/,/}/s/^[[:space:]]*"\([^"]*\)"[[:space:]]*:.*/\1/p' "$package_json"
+  fi
+}
+
+offer_nodejs_script_selection() {
+  if $IS_TOOL; then
+    return 1
+  fi
+
+  cd "$START_DIR" || return 1
+  while :; do
+    if [ -f package.json ]; then
+      scripts=$(list_package_scripts package.json)
+      if [ -n "$scripts" ]; then
+        package_dir="$PWD"
+        tool=$(detect_nodejs_tool)
+        cd "$package_dir" || return 1
+        has_command_or_error "$tool" package.json
+
+        echo "No way to $ACTION found :'("
+        echo ""
+        printf "Assign a package script to '$ACTION' for this project? [y/N]:"
+        if ! read -r assign_script; then
+          exit 1
+        fi
+        echo ""
+
+        case "$assign_script" in
+        y | Y | yes | YES)
+          ;;
+        *)
+          return 1
+          ;;
+        esac
+
+        echo "Available package scripts:"
+
+        i=1
+        for script in $scripts; do
+          echo "  $i) $script"
+          i=$((i + 1))
+        done
+
+        printf "Select a script to run: "
+        if ! read -r selected_number; then
+          exit 1
+        fi
+
+        i=1
+        for script in $scripts; do
+          if [ "$selected_number" = "$i" ]; then
+            write_action_script_assignment "$PWD" "$script"
+            execute_command "$tool" "run $script"
+          fi
+          i=$((i + 1))
+        done
+
+        echo "Invalid selection."
+        exit 1
+      fi
+    fi
+
+    if ! go_up; then
+      return 1
+    fi
+  done
 }
 
 # Rust + Cargo
@@ -480,6 +611,7 @@ set_project_root() {
 }
 
 nothing_found() {
+  offer_nodejs_script_selection
   echo "No way to $ACTION found :'("
   exit 1
 }
@@ -567,6 +699,8 @@ else
 fi
 
 set_project_root
+
+START_DIR="$PWD"
 
 while :; do
   detect_and_run

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,6 +17,9 @@ script_directory=$(CDPATH="$(cd -- "$(dirname -- "$0")")" && pwd -P)
 
 # Set this variable to ensure top level Makefile doesn't affect the results.
 export PROJECT_ROOT="${script_directory}/tests"
+export PROJECTDO_CONFIG_DIR="${script_directory}/tests/.projectdo"
+rm -rf "$PROJECTDO_CONFIG_DIR"
+trap 'rm -rf "$PROJECTDO_CONFIG_DIR"' EXIT HUP INT TERM
 
 describe() {
   printf "\n%s%s%s" "$BOLD" "$1" "$RESET"
@@ -199,6 +202,26 @@ if describe "npm / yarn / pnpm / bun"; then
     do_test_in "npm-without-test"
     assert
     assertEqual "$RUN_RESULT" "make test"
+  fi
+  if it "offers to assign package scripts if no matching npm script is found"; then
+    rm -rf "$PROJECTDO_CONFIG_DIR"
+    RUN_RESULT=$(cd tests/npm-without-start && printf 'y\n2\n' | "$script_directory"/projectdo -n run)
+    RUN_EXIT=$?
+    assert
+    assertEqual "$RUN_RESULT" "No way to run found :'(
+
+Assign a package script to 'run' for this project? [y/N]:
+Available package scripts:
+  1) build
+  2) dev
+  3) test
+Select a script to run: npm run dev"
+  fi
+  if it "uses an assigned package script for the project action"; then
+    RUN_RESULT=$(cd tests/npm-without-start && "$script_directory"/projectdo -n run)
+    RUN_EXIT=$?
+    assert
+    assertEqual "$RUN_RESULT" "npm run dev"
   fi
   if it "can print tool"; then
     do_print_tool_in "npm"

--- a/tests/npm-without-start/package.json
+++ b/tests/npm-without-start/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "echo build",
+    "dev": "echo dev",
+    "test": "echo test"
+  }
+}


### PR DESCRIPTION
Hi! This adds a small fallback for Node projects when `projectdo` can't find a script for the requested action.

For example, if `projectdo run` does not find a `start` script, it can now ask whether you want to assign one of the existing `package.json` scripts to `run`. The choice is saved under `~/.projectdo`, so the next time the same action is used in that project, it can run directly.

I kept the saved value as the package script name instead of the resolved command, so it still works if the project changes from npm to yarn, pnpm, or bun later.

Also added regression coverage for both the interactive assignment and the saved mapping behavior.
